### PR TITLE
Add directory URL redirects to site template

### DIFF
--- a/site-template/public/_redirects
+++ b/site-template/public/_redirects
@@ -1,0 +1,2 @@
+# Redirect directory URLs to their README page
+/*/  /:splat/readme  301


### PR DESCRIPTION
## Summary

- Adds `_redirects` file to `site-template/public/` so Cloudflare Pages redirects `/topic/` to `/topic/readme`
- Fixes 404s when navigating to directory URLs or clicking cross-topic links in README files

## Test plan

- [ ] Deploy a Lattice site with topic directories containing README.md files
- [ ] Verify `/topic/` redirects to `/topic/readme` (301)
- [ ] Verify cross-topic links like `../other-topic/` resolve correctly

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)